### PR TITLE
Introduce IIconGravityProvider to define icon alignment in TabPageIndicator

### DIFF
--- a/Library/Interfaces/IIconGravityProvider.cs
+++ b/Library/Interfaces/IIconGravityProvider.cs
@@ -1,0 +1,10 @@
+﻿using Android.Views;
+
+namespace DK.Ostebaronen.Droid.ViewPagerIndicator.Interfaces
+{
+    public interface IIconGravityProvider
+    {
+        GravityFlags IconGravity { get; }
+    }
+}
+

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ViewPagerIndicatorEventHandlers.cs" />
     <Compile Include="TitlePageIndicator.cs" />
     <Compile Include="UnderlinePageIndicator.cs" />
+    <Compile Include="Interfaces\IIconGravityProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\color\vpi__dark_theme.xml" />

--- a/Library/TabPageIndicator.cs
+++ b/Library/TabPageIndicator.cs
@@ -98,7 +98,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
                 RemoveCallbacks(_tabSelector);
         }
 
-        private void AddTab(int index, ICharSequence text, int iconResId)
+        private void AddTab(int index, ICharSequence text, int iconResId, GravityFlags iconGravity)
         {
             var tabView = new TabView(Context, this) {Focusable = true, Index = index, TextFormatted = text};
             tabView.Click += (sender, args) =>
@@ -113,7 +113,23 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
             };
 
             if (iconResId != 0)
-                tabView.SetCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+            {
+                switch (iconGravity) {
+                case GravityFlags.Top:
+                    tabView.SetCompoundDrawablesWithIntrinsicBounds(0, iconResId, 0, 0);
+                    break;
+                case GravityFlags.Right:
+                    tabView.SetCompoundDrawablesWithIntrinsicBounds(0, 0, iconResId, 0);
+                    break;
+                case GravityFlags.Bottom:
+                    tabView.SetCompoundDrawablesWithIntrinsicBounds(0, 0, 0, iconResId);
+                    break;
+                case GravityFlags.Left:
+                default:
+                    tabView.SetCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+                    break;
+                }
+            }
 
             _tabLayout.AddView(tabView, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MatchParent, 1));
         }
@@ -179,9 +195,9 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
         {
             _tabLayout.RemoveAllViews();
             var adapter = _viewPager.Adapter;
-            IIconPageAdapter iconAdapter = null;
-            if (adapter is IIconPageAdapter)
-                iconAdapter = (IIconPageAdapter)adapter;
+            var iconAdapter = adapter as IIconPageAdapter;
+            var gravityProvider = adapter as IIconGravityProvider;
+            var iconGravity = gravityProvider != null ? gravityProvider.IconGravity : GravityFlags.NoGravity;
 
             var count = adapter.Count;
             for(var i = 0; i < count; i++)
@@ -191,7 +207,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
                 var iconResId = 0;
                 if (iconAdapter != null)
                     iconResId = iconAdapter.GetIconResId(i);
-                AddTab(i, title, iconResId);
+                AddTab(i, title, iconResId, iconGravity);
             }
             if (_selectedTabIndex > count)
                 _selectedTabIndex = count - 1;

--- a/Libraryv4/Libraryv4.csproj
+++ b/Libraryv4/Libraryv4.csproj
@@ -77,6 +77,9 @@
     </Compile>
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\Library\Interfaces\IIconGravityProvider.cs">
+      <Link>Interfaces\IIconGravityProvider.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="..\Library\Resources\color\vpi__dark_theme.xml">

--- a/Sample/Tabs/SampleTabsWithIcons.cs
+++ b/Sample/Tabs/SampleTabsWithIcons.cs
@@ -5,6 +5,7 @@ using DK.Ostebaronen.Droid.ViewPagerIndicator;
 using DK.Ostebaronen.Droid.ViewPagerIndicator.Interfaces;
 using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
+using Android.Views;
 
 namespace Sample.Tabs
 {
@@ -27,7 +28,9 @@ namespace Sample.Tabs
             _indicator.SetViewPager(_pager);
         }
 
-        private class GoogleMusicAdapter : TestFragmentAdapter, IIconPageAdapter 
+        private class GoogleMusicAdapter : TestFragmentAdapter, IIconPageAdapter
+        // TODO uncomment to see IIconGravityProvider effect (the icon renders on top of the tab title)
+        //, IIconGravityProvider
         {
             private static readonly string[] Content =
             {
@@ -56,6 +59,11 @@ namespace Sample.Tabs
             public override Fragment GetItem(int p0) { return TestFragment.NewInstance(Content[p0 % Content.Length]); }
 
             public override Java.Lang.ICharSequence GetPageTitleFormatted(int p0) { return new Java.Lang.String(Content[p0 % Content.Length].ToUpper()); }
+
+            public GravityFlags IconGravity
+            {
+                get { return GravityFlags.Top; }
+            }
         }
     }
 }

--- a/Sample/TestFragmentAdapter.cs
+++ b/Sample/TestFragmentAdapter.cs
@@ -1,10 +1,9 @@
 using Android.Support.V4.App;
 using DK.Ostebaronen.Droid.ViewPagerIndicator.Interfaces;
-using Android.Views;
 
 namespace Sample
 {
-    public class TestFragmentAdapter : FragmentPagerAdapter, IIconPageAdapter, IIconGravityProvider
+    public class TestFragmentAdapter : FragmentPagerAdapter, IIconPageAdapter
     {
         private static readonly string[] Content = {"This", "Is", "A", "Test"};
         private static readonly int[] Icons =
@@ -48,11 +47,6 @@ namespace Sample
         public int GetIconResId(int index)
         {
             return Icons[index % Icons.Length];
-        }
-
-        public GravityFlags IconGravity
-        {
-            get { return GravityFlags.Top; }
         }
     }
 }

--- a/Sample/TestFragmentAdapter.cs
+++ b/Sample/TestFragmentAdapter.cs
@@ -1,9 +1,10 @@
 using Android.Support.V4.App;
 using DK.Ostebaronen.Droid.ViewPagerIndicator.Interfaces;
+using Android.Views;
 
 namespace Sample
 {
-    public class TestFragmentAdapter : FragmentPagerAdapter, IIconPageAdapter
+    public class TestFragmentAdapter : FragmentPagerAdapter, IIconPageAdapter, IIconGravityProvider
     {
         private static readonly string[] Content = {"This", "Is", "A", "Test"};
         private static readonly int[] Icons =
@@ -47,6 +48,11 @@ namespace Sample
         public int GetIconResId(int index)
         {
             return Icons[index % Icons.Length];
+        }
+
+        public GravityFlags IconGravity
+        {
+            get { return GravityFlags.Top; }
         }
     }
 }


### PR DESCRIPTION
Implement IIconGravityProvider interface at adapter and use Left, Top, Right, Bottom values of GravityFlags to define icon alignment.