### PR TITLE
Fix underline fade when alpha component is not 0xFF

### DIFF
--- a/Library/UnderlinePageIndicator.cs
+++ b/Library/UnderlinePageIndicator.cs
@@ -36,7 +36,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
         private int _activePointerId = InvalidPointer;
         private bool _isDragging;
         private int _currentPage;
-
+        private Color _selectedColor;
         private readonly Runnable _fadeRunnable;
 
         public event PageScrollStateChangedEventHandler PageScrollStateChanged;
@@ -108,7 +108,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
                     else
                     {
                         RemoveCallbacks(_fadeRunnable);
-                        _paint.Alpha = 0xFF;
+                        _paint.Alpha = Color.GetAlphaComponent(_selectedColor);
                         Invalidate();
                     }
                 }
@@ -123,7 +123,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
             set
             {
                 _fadeLength = value;
-                _fadeBy = 0xFF / (_fadeLength / FadeFrameMs);
+                _fadeBy = Color.GetAlphaComponent(_selectedColor) / (_fadeLength / FadeFrameMs);
             }
         }
 
@@ -132,6 +132,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
             get { return _paint.Color; }
             set
             {
+                _selectedColor = value;
                 _paint.Color = value;
                 Invalidate();
             }
@@ -309,7 +310,7 @@ namespace DK.Ostebaronen.Droid.ViewPagerIndicator
                 if (positionOffsetPixels > 0)
                 {
                     RemoveCallbacks(_fadeRunnable);
-                    _paint.Alpha = 0xFF;
+                    _paint.Alpha = Color.GetAlphaComponent(_selectedColor);
                 }
                 else if(_scrollState != ViewPager.ScrollStateDragging)
                     PostDelayed(_fadeRunnable, FadeFrameMs);

--- a/Sample/Underlines/SampleUnderlinesStyledMethods.cs
+++ b/Sample/Underlines/SampleUnderlinesStyledMethods.cs
@@ -23,7 +23,7 @@ namespace Sample.Underlines
 
             var indicator = FindViewById<UnderlinePageIndicator>(Resource.Id.indicator);
             indicator.SetViewPager(_pager);
-            indicator.SelectedColor = Color.Argb(0xFF, 0xCC, 0x00, 0x00);
+            indicator.SelectedColor = Color.Argb(0x33, 0xCC, 0x00, 0x00);
             indicator.SetBackgroundColor(Color.Argb(0xFF, 0xCC, 0xCC, 0xCC));
             indicator.FadeLength = 1000;
             indicator.FadeDelay = 1000;


### PR DESCRIPTION
Reported here: https://github.com/JakeWharton/ViewPagerIndicator/pull/325